### PR TITLE
Adding resources to classpath

### DIFF
--- a/src/main/groovy/frege/gradle/plugins/FregePlugin.groovy
+++ b/src/main/groovy/frege/gradle/plugins/FregePlugin.groovy
@@ -17,7 +17,7 @@ class FregePlugin implements Plugin<Project> {
         project.plugins.apply(FregeBasePlugin)
         project.plugins.apply("java")
 
-        def replTask = project.task('fregeRepl', type: FregeRepl, group: 'frege', dependsOn: 'compileFrege')
+        def replTask = project.task('fregeRepl', type: FregeRepl, group: 'frege', dependsOn: ['compileFrege', 'processResources'])
         replTask.outputs.upToDateWhen { false } // always run, regardless of up to date checks
 
         def checkTask = project.task('fregeQuickCheck', type: FregeQuickCheck, group: 'frege', dependsOn: 'testClasses')

--- a/src/main/groovy/frege/gradle/tasks/FregeRepl.groovy
+++ b/src/main/groovy/frege/gradle/tasks/FregeRepl.groovy
@@ -1,5 +1,7 @@
 package frege.gradle.tasks
 
+import org.gradle.api.file.FileCollection
+import org.gradle.api.Project
 import org.gradle.api.DefaultTask
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.tasks.*
@@ -8,8 +10,9 @@ import org.gradle.process.internal.JavaExecAction
 
 class FregeRepl extends DefaultTask {
 
-    static String DEFAULT_SRC_DIR        = "src/main/frege"     // TODO: should this come from a source set?
-    static String DEFAULT_CLASSES_SUBDIR = "classes/main"       // TODO: should this come from a convention?
+    static String DEFAULT_SRC_DIR           = "src/main/frege"     // TODO: should this come from a source set?
+    static String DEFAULT_RESOURCES_SUBDIR  = "resources/main"     // TODO: should this come from a convention?
+    static String DEFAULT_CLASSES_SUBDIR    = "classes/main"       // TODO: should this come from a convention?
 
     @Optional @InputDirectory
     File sourceDir = new File(project.projectDir, DEFAULT_SRC_DIR).exists() ?  new File(project.projectDir, DEFAULT_SRC_DIR) : null
@@ -17,9 +20,11 @@ class FregeRepl extends DefaultTask {
     @Optional @OutputDirectory
     File targetDir = new File(project.buildDir, DEFAULT_CLASSES_SUBDIR)
 
+    @Optional @OutputDirectory
+    File resourcesDir = new File(project.buildDir, DEFAULT_RESOURCES_SUBDIR)
+
     @TaskAction
     void openFregeRepl() {
-
         if (sourceDir != null && !sourceDir.exists() ) {
             def currentDir = new File('.')
             logger.info "Intended source dir '${sourceDir.absolutePath}' doesn't exist. Using current dir '${currentDir.absolutePath}' ."
@@ -28,12 +33,26 @@ class FregeRepl extends DefaultTask {
 
         FileResolver fileResolver = getServices().get(FileResolver.class)
         JavaExecAction action = new DefaultJavaExecAction(fileResolver)
+
         action.setMain("frege.repl.FregeRepl")
         action.workingDir = sourceDir ?: project.projectDir
         action.standardInput = System.in
-        action.setClasspath(project.files(project.configurations.runtime ) + project.files(targetDir.absolutePath))
+        action.setClasspath(
+            // dependencies
+            project.files(project.configurations.runtime) +
+            // compiled source code
+            addFiles(project, targetDir) +
+            // resource files
+            addFiles(project, resourcesDir)
+        )
 
         action.execute()
+    }
+
+    FileCollection addFiles(Project project, File file) {
+        return !file?.exists() ?
+            Project.files() :
+            project.files(file.absolutePath)
     }
 
 }


### PR DESCRIPTION
- (adb147b) Resources (`src/main/resources`) are not copied to `build/resources/main` path when executing `FregeRepl`.  You can achieve that by running `build` before executing `fregeRepl`, but it would be nice if `fregeRepl` could depend on `processResources`. 
- (85bed0a) Even if I copy manually resources to the `build/resources/main` path (or execute `build` task), resources are not included in the classpath at runtime when executing `fregeRepl` task.
